### PR TITLE
Update CORS policy origins in Program.cs

### DIFF
--- a/SmartLeadsPortalDotNetApi/Program.cs
+++ b/SmartLeadsPortalDotNetApi/Program.cs
@@ -152,8 +152,8 @@ builder.Services.AddCors(options =>
         builder.WithOrigins(
             localDev,
             localDevhttps,
-            "smartleads-export.kis-systems.com",
-            "https://smartleads-export.kis-systems.com")
+            "https://smartleads-export.kis-systems.com",
+            "https://smartleadsportal-test.kineticstaff.com")
         .AllowAnyHeader()
         .AllowAnyMethod()
         .AllowCredentials()


### PR DESCRIPTION
The CORS policy named "CorsApi" in `Program.cs` has been updated. The origin "smartleads-export.kis-systems.com" and its HTTPS version were removed from the allowed origins list. The HTTPS version of "smartleads-export.kis-systems.com" was re-added, and a new origin "https://smartleadsportal-test.kineticstaff.com" was added. This ensures requests from these specified origins are allowed, while maintaining the same settings for headers, methods, credentials, and exposed headers.