### PR TITLE
Retrieve SQL connection string from env variable first

### DIFF
--- a/SmartLeadsPortalDotNetApi/Database/DbConnectionFactory.cs
+++ b/SmartLeadsPortalDotNetApi/Database/DbConnectionFactory.cs
@@ -16,8 +16,9 @@ public class DbConnectionFactory : IDisposable
 
     public DbConnectionFactory(IConfiguration configuration, ILogger<DbConnectionFactory> logger)
     {
-        _sqlConnectionString = configuration.GetConnectionString("SmartLeadsSQLServerDBConnectionString")
-            ?? throw new ArgumentNullException(nameof(configuration), "Smart Leads SQL Server connection string is missing.");
+        _sqlConnectionString = Environment.GetEnvironmentVariable("ConnectionStrings:SmartleadsPortalDb") 
+            ?? configuration.GetConnectionString("SmartLeadsSQLServerDBConnectionString")
+            ?? throw new InvalidOperationException("SmartleadsPortalDb connection string is missing.");
 
         // _leadsqlConnectionString = configuration.GetConnectionString("LeadsPortalSQLServerDBConnectionString")
         //     ?? throw new ArgumentNullException(nameof(configuration), "Robotics Leads SQL Server connection string is missing.");


### PR DESCRIPTION
Updated DbConnectionFactory to first attempt to retrieve the SQL connection string from the environment variable `ConnectionStrings:SmartleadsPortalDb`. If the environment variable is not set, it falls back to the configuration file for `SmartLeadsSQLServerDBConnectionString`. If neither is available, an `InvalidOperationException` is thrown instead of an `ArgumentNullException`. This change enhances flexibility for different deployment environments.