### PR TITLE
Add log statement to DbConnectionFactory constructor

### DIFF
--- a/SmartLeadsPortalDotNetApi/Database/DbConnectionFactory.cs
+++ b/SmartLeadsPortalDotNetApi/Database/DbConnectionFactory.cs
@@ -26,6 +26,7 @@ public class DbConnectionFactory : IDisposable
         // _mysqlConnectionString = configuration.GetConnectionString("MySQLDBConnectionString")
         //     ?? throw new ArgumentNullException(nameof(configuration), "MySQL connection string is missing.");
         this.logger = logger;
+        this.logger.LogInformation($"SQL Connection String From Environment: {Environment.GetEnvironmentVariable("ConnectionStrings:SmartleadsPortalDb")}");
         this.logger.LogInformation($"SQL Connection String: {this._sqlConnectionString}");
     }
 


### PR DESCRIPTION
Added a log statement in the DbConnectionFactory constructor to log the SQL connection string retrieved from the environment variable `ConnectionStrings:SmartleadsPortalDb`. This helps in debugging by providing visibility into the connection string being used.