### PR TITLE
Comment out database connection validation on startup

### DIFF
--- a/SmartLeadsPortalDotNetApi/Program.cs
+++ b/SmartLeadsPortalDotNetApi/Program.cs
@@ -189,11 +189,11 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 var app = builder.Build();
 
 // Trigger database connection validation on startup
-using (var scope = app.Services.CreateScope())
-{
-    var dbConnectionFactory = scope.ServiceProvider.GetRequiredService<DbConnectionFactory>();
-    dbConnectionFactory.ValidateConnections();
-}
+//using (var scope = app.Services.CreateScope())
+//{
+//    var dbConnectionFactory = scope.ServiceProvider.GetRequiredService<DbConnectionFactory>();
+//    dbConnectionFactory.ValidateConnections();
+//}
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())


### PR DESCRIPTION
The code that creates a service scope, retrieves the DbConnectionFactory, and calls its ValidateConnections method has been commented out. This means database connection validation will no longer occur during the application's startup process.